### PR TITLE
feat(): change withdraw function

### DIFF
--- a/test/AAVELendingService.ts
+++ b/test/AAVELendingService.ts
@@ -89,6 +89,7 @@ describe.skip("Aave Lending Service (Kovan)", function () {
       await sendingTx.wait();
       const depositTx = await lendingService.deposit(depositAmount);
       await depositTx.wait();
+      const daiBalanceBefore = await dai.balanceOf(signer1.address);
 
       // Tokens after deposit
       const aToken = await ethers.getContractAt("IERC20", registeredATokenAddress);
@@ -101,12 +102,13 @@ describe.skip("Aave Lending Service (Kovan)", function () {
 
       const aTokenBalanceOfAaveLendingAfterWithdraw = await aToken.balanceOf(lendingService.address);
       console.log(`aTokenBalanceOfAaveLendingAfterDeposit`, aTokenBalanceOfAaveLendingAfterWithdraw.toString());
-      const daiBalance = await dai.balanceOf(signer1.address);
+      const daiBalanceAfter = await dai.balanceOf(signer1.address);
 
+      const expectedDaiBalance = daiBalanceAfter.sub(daiBalanceBefore);
       expect(aTokenBalanceOfAaveLendingAfterWithdraw).to.be.at.least(
         aTokenBalanceOfAaveLendingAfterWithdraw.div(parseUnits18("2")),
       );
-      expect(daiBalance).to.be.at.least(parseUnits18("25"));
+      expect(expectedDaiBalance).to.be.at.least(parseUnits18("25"));
     });
   });
 });

--- a/test/RentalAgreement.ts
+++ b/test/RentalAgreement.ts
@@ -7,12 +7,10 @@ import { MockLendingService } from "../typechain/MockLendingService";
 import { expect } from "chai";
 import { BigNumber, Contract } from "ethers";
 import { deployMockLendingService } from "./utils/mockLendingService";
+import { parseUnits18 } from "../utils/parseUnits";
 
 const { deployContract } = hre.waffle;
 const { ethers } = hre;
-
-// TODO: to move
-const parseUnits18 = (stringToParse: string) => ethers.utils.parseEther(stringToParse);
 
 const increaseEVMTime = async (time: number) => {
   await ethers.provider.send("evm_increaseTime", [time]);
@@ -54,7 +52,7 @@ describe("Rental Agreement", function () {
     deposit = parseUnits18("500");
     rentGuarantee = parseUnits18("1500");
 
-    lendingService = await deployMockLendingService(landlord, dai)
+    lendingService = await deployMockLendingService(landlord, dai);
 
     const rentalArtifact: Artifact = await hre.artifacts.readArtifact("RentalAgreement");
     rental = <RentalAgreement>(


### PR DESCRIPTION
A few changes:

1. I think it was missing a check to compare the amount to withdraw with the contract's balance
2. `safeTransfer` was added in `withdrawCapitalAndInterests` but not in this one, so that's now fixed
3. Re: Amount to withdraw:
When looking at this
https://github.com/Web3-Architects/open-rental/blob/36f560f8eaaee674917c217b1c09a55ca31f74ce/contracts/RentalAgreement.sol#L104

With the current implementation an amount different than `rent` would be transferred to `RentalAgreement` but then we do:
https://github.com/Web3-Architects/open-rental/blob/36f560f8eaaee674917c217b1c09a55ca31f74ce/contracts/RentalAgreement.sol#L105
Leaving the difference in `RentalAgreement`... (The landlord is not getting any interests)

So maybe we can only withdraw interests with `withdrawCapitalAndInterests`? @JulienKode 
If that's okay, I'll update the tests.